### PR TITLE
fix inference on CPU

### DIFF
--- a/localizer/predict.py
+++ b/localizer/predict.py
@@ -183,7 +183,7 @@ class Localizer:
                                  strides=1,
                                  padding='SAME', name='confidence_map')
 
-        confidence_loc_max = (tf.nn.max_pool(confidence_map, 3, 1, 'SAME', 'NCDHW') - confidence_map) == 0
+        confidence_loc_max = (tf.nn.max_pool(confidence_map, 3, 1, 'SAME', 'NDHWC') - confidence_map) == 0
         confidence_thr = tf.math.logical_and(confidence_loc_max, confidence_map >= self._cfg['confidence_thr'])
         confidence = confidence_map * tf.cast(confidence_thr, tf.float32)
 


### PR DESCRIPTION
Previously you would get "Default Pooling3DOp only supports NDHWC on device type CPU".

With this change inference works fine for me. Not sure if any other logic change is needed. I do not thoroughly understand this function so it might introduce some subtle bugs. In other places `NDHWC` (or `NHWC`) is used. Not sure why its is `NDHWC` here.